### PR TITLE
Update link to integration guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Criteo Adapters for Google Mediation (iOS)
 
-This repository contains Criteo’s Adapter for Admob Mediation. It must be used in conjunction with the Criteo Publisher SDK. For requirements, intructions, and other info, see [Integrating Criteo with Admob Mediation](https://publisherdocs.criteotilt.com/sdk-ios/3.1/admob-mediation/).
+This repository contains Criteo’s Adapter for Admob Mediation. It must be used in conjunction with the Criteo Publisher SDK. For requirements, intructions, and other info, see [Integrating Criteo with Admob Mediation](https://publisherdocs.criteotilt.com/app/ios/mediation/admob/).
 
 License
 [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html)


### PR DESCRIPTION
Update link to integration guide to the new documentation. Although the old link still works and redirects to the new link, the redirect may be decommissioned in near future.